### PR TITLE
Switch to alpine 3.18 & add AZP_ARGS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sh text eol=lf
+*.ps1 text eol=lf
+Dockerfile text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
+# Azure CLI not compatible with alpine3.19
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.18 AS build
 ARG BUILD_AZP_TOKEN
 ARG BUILD_AZP_URL
 ARG BUILD_AZP_VERSION=1.0.0.0

--- a/primedotnet.ps1
+++ b/primedotnet.ps1
@@ -1,5 +1,5 @@
 #!/usr/share/powershell/pwsh
-$ErrorActionPreference = "Stop" 
+$ErrorActionPreference = "Stop"
 Set-StrictMode -Version 7.3
 
 [string[]] $netversions = @(

--- a/start.sh
+++ b/start.sh
@@ -67,4 +67,4 @@ chmod +x ./run.sh
 
 # To be aware of TERM and INT signals call ./run.sh
 # Running it with the --once flag at the end will shut down the agent after the build is executed
-./run.sh "$@" & wait $!
+./run.sh "$@ ${AZP_ARGS}" & wait $!


### PR DESCRIPTION
* Azure CLI not compatible with Python version in 3.19
* Add support for additional arguments via environment variable