### PR TITLE
Add libssl-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV BUILD_AZP_VERSION="${BUILD_AZP_VERSION}"
 
 RUN apk update \
     && apk upgrade \
-    && apk add bash curl git icu-libs jq gcc musl-dev python3-dev libffi-dev openssl-dev cargo make py3-pip nodejs npm zip gnupg libintl
+    && apk add bash curl git icu-libs jq gcc musl-dev python3-dev libffi-dev openssl-dev libssl-dev cargo make py3-pip nodejs npm zip gnupg libintl
 
 
 # Install Azure CLI


### PR DESCRIPTION
Trying to solve build error:

/azp/nuget/NUGET_PACKAGES/microsoft.azure.webjobs.script.extensionsmetadatagenerator/4.0.1/build/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets(37,5): error : Metadata generation failed. Exit code: '134' Error: 'No usable version of libssl was found' [/tmp/komhufjb.hib/WorkerExtensions.csproj]